### PR TITLE
Removed package "sanity-cli" from the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
 	"scripts": {
 		"start": "sanity start",
 		"test": "sanity check",
-		"dev": "sanity dev"
+		"dev": "sanity dev",
+		"deploy": "sanity deploy"
 	},
 	"keywords": [
 		"sanity"
 	],
 	"dependencies": {
-		"@sanity/cli": "^5.13.0",
 		"@sanity/components": "^2.14.0",
 		"@sanity/dashboard": "^5.0.1",
 		"@sanity/icons": "^3.7.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@sanity/cli':
-        specifier: ^5.13.0
-        version: 5.13.0(@noble/hashes@2.0.1)(@types/node@25.3.3)(@types/react@19.2.14)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(lightningcss@1.31.1)(react@19.2.4)(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.2)(yaml@2.8.2)
       '@sanity/components':
         specifier: ^2.14.0
         version: 2.14.0


### PR DESCRIPTION
@deesky this has been done so that you rely on the global install of Sanity rather than a project specific version. This will help with:
* Excesive loging in.
* Confirmation of outdated Sanity instances